### PR TITLE
Fixed session Persistence including adding /logout endpoint

### DIFF
--- a/backend/src/main/java/sysc4806group25/monkeypoll/config/SecurityConfig.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/config/SecurityConfig.java
@@ -13,6 +13,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 import sysc4806group25.monkeypoll.service.AccountUserDetailsService;
 
 import static org.springframework.security.config.Customizer.withDefaults;
@@ -38,8 +39,9 @@ public class SecurityConfig {
 
                 )
                 .httpBasic(withDefaults())
+                .logout((logout) -> logout.addLogoutHandler(new SecurityContextLogoutHandler()))
                 .csrf(csrf->
-                        csrf.ignoringRequestMatchers("/register", "/login")
+                        csrf.ignoringRequestMatchers("/register", "/login", "/logout") // this allows us to test using postman
                 );
 
         return http.build();

--- a/backend/src/main/java/sysc4806group25/monkeypoll/controller/AccountController.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/controller/AccountController.java
@@ -1,5 +1,7 @@
 package sysc4806group25.monkeypoll.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -10,6 +12,8 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.context.SecurityContextHolderStrategy;
+import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextRepository;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,12 +30,15 @@ public class AccountController {
     @Autowired
     AccountUserDetailsService accountUserDetailsService;
 
+    private SecurityContextRepository securityContextRepository =
+            new HttpSessionSecurityContextRepository();
+
     public AccountController(AuthenticationManager authenticationManager) {
         this.authenticationManager = authenticationManager;
     }
 
     @PostMapping("/login")
-    public Account loginAccount(@RequestBody LoginRequest loginRequest) {
+    public Account loginAccount(@RequestBody LoginRequest loginRequest, HttpServletRequest request, HttpServletResponse response) {
 
         UsernamePasswordAuthenticationToken token = UsernamePasswordAuthenticationToken.unauthenticated(
                 loginRequest.email(), loginRequest.password());
@@ -41,6 +48,8 @@ public class AccountController {
             SecurityContext context = this.securityContextHolderStrategy.createEmptyContext();
             context.setAuthentication(authentication);
             this.securityContextHolderStrategy.setContext(context);
+            securityContextRepository.saveContext(context, request, response);
+
             return (Account) context.getAuthentication().getPrincipal();
 
         } catch (AuthenticationException e) {

--- a/frontend/src/MenuBar.jsx
+++ b/frontend/src/MenuBar.jsx
@@ -1,17 +1,33 @@
-import {useContext, useState} from 'react';
+import {useContext, useRef, useState} from 'react';
 
 import {Button} from 'primereact/button';
 
 import LoginDialog from "./welcome/LoginDialog.jsx";
 import {UserContext} from "./context/UserContext.jsx";
+import {logoutUser} from "./api/userApi.js";
 
 
 const MenuBar = () => {
+    const toast = useRef(null);
     const [loginVisible, setLoginVisible] = useState(false);
     const [user, setUser] = useContext(UserContext);
 
-    const handleLogout = () => {
+    const handleLogout = async () => {
+
+        const logoutStatus = await logoutUser();
         setUser(null);
+        console.log("point a")
+        if (logoutStatus.success) {
+            setUser(null);
+            console.log("point b")
+        } else {
+            toast.current.show({
+                severity: 'error',
+                life: 3000,
+                summary: 'Logout Error',
+                detail: logoutStatus.body.message,
+            });
+        }
     };
 
     return (

--- a/frontend/src/MenuBar.jsx
+++ b/frontend/src/MenuBar.jsx
@@ -15,11 +15,8 @@ const MenuBar = () => {
     const handleLogout = async () => {
 
         const logoutStatus = await logoutUser();
-        setUser(null);
-        console.log("point a")
         if (logoutStatus.success) {
             setUser(null);
-            console.log("point b")
         } else {
             toast.current.show({
                 severity: 'error',

--- a/frontend/src/api/userApi.js
+++ b/frontend/src/api/userApi.js
@@ -59,3 +59,31 @@ export const registerUser = async (firstName, lastName, email, password) => {
 
     return status;
 }
+
+/*
+Logout the user that is currently logged in.
+Return:
+- Success: True if user has been successfully logged out on the server side
+- Body - No content (204) on success or message describing the error
+*/
+export const logoutUser = async () => {
+
+    const requestOptions = {
+        method: 'POST',
+    };
+
+    const response = await fetch(`logout`, requestOptions);
+
+    const status = {
+        success: false,
+        body: {
+            message: "Failed to logout user"
+        }
+    }
+
+    if (response.ok) {
+        status.success = true;
+    }
+
+    return status;
+}


### PR DESCRIPTION
### Additions
- User sessions are now properly stored and persisted across requests in the backend by saving the authenticated context in a spring `securityContextRepository` (see the documenation [here](https://docs.spring.io/spring-security/reference/servlet/authentication/session-management.html#store-authentication-manually) for more details)
  - This means that once a user is logged it, any subsequent requests with automatically be authenticated as that user
A `/logout` endpoint is now available to log out the current user, implemented using Spring's `SecurityContextLogoutHandler` defined in our `/config/SecurityConfig.java` (see the documentation [here](https://docs.spring.io/spring-security/reference/servlet/authentication/logout.html) for more details)
  - `/logout` is a POST endpoint (with an empty body) and will return `204 - No Content` on successful logout
  - This endpoint needed to be included to close #46 properly as without it we would be unable to clear sessions on the server side
  - Note that the endpoint is automatically created by the `SecurityContextLogoutHandler` which is why it's not explicitly defined anywhere a Controller
- The logout button in the MenuBar now makes a call to `/logout` to logout the user on the server-side

Since this is my first shot at playing with the frontend, let me know if how I modified the MenuBar to add the api call makes sense and if there's anything I should change/a better way of doing this!

This closes #46. Sorry for the double PR for this branch, I forgot to add that last commit 🤦‍♂️ 