### PR TITLE
#56: Initial Implementation of GET /survey Controller

### DIFF
--- a/backend/src/main/java/sysc4806group25/monkeypoll/config/SecurityConfig.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests((requests) -> requests
-                        .requestMatchers("/", "/*.html", "/*.svg", "/*.png", "/assets/**", "/error", "/register", "/login", "/surveys/**").permitAll()
+                        .requestMatchers("/", "/*.html", "/*.svg", "/*.png", "/assets/**", "/error", "/register", "/login", "/survey/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .httpBasic(withDefaults())

--- a/backend/src/main/java/sysc4806group25/monkeypoll/config/SecurityConfig.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package sysc4806group25.monkeypoll.config;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -34,15 +33,12 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests((requests) -> requests
-                        .requestMatchers("/", "/*.html", "/*.svg", "/*.png", "/assets/**","/error", "/register", "/login").permitAll()
+                        .requestMatchers("/", "/*.html", "/*.svg", "/*.png", "/assets/**", "/error", "/register", "/login", "/surveys/**").permitAll()
                         .anyRequest().authenticated()
-
                 )
                 .httpBasic(withDefaults())
                 .logout((logout) -> logout.addLogoutHandler(new SecurityContextLogoutHandler()))
-                .csrf(csrf->
-                        csrf.ignoringRequestMatchers("/register", "/login", "/logout") // this allows us to test using postman
-                );
+                .csrf(csrf -> csrf.ignoringRequestMatchers("/register", "/login", "/logout", "/surveys/")); // this allows us to test using postman
 
         return http.build();
     }
@@ -56,5 +52,4 @@ public class SecurityConfig {
 
         return new ProviderManager(authenticationProvider);
     }
-
 }

--- a/backend/src/main/java/sysc4806group25/monkeypoll/controller/AccountController.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/controller/AccountController.java
@@ -14,12 +14,15 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.security.web.context.SecurityContextRepository;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 import sysc4806group25.monkeypoll.model.Account;
+import sysc4806group25.monkeypoll.model.Survey;
 import sysc4806group25.monkeypoll.service.AccountUserDetailsService;
+import sysc4806group25.monkeypoll.service.SurveyService;
+
+
+import java.util.Optional;
 
 @RestController
 public class AccountController {
@@ -29,6 +32,9 @@ public class AccountController {
 
     @Autowired
     AccountUserDetailsService accountUserDetailsService;
+
+    @Autowired
+    SurveyService surveyService;
 
     private SecurityContextRepository securityContextRepository =
             new HttpSessionSecurityContextRepository();
@@ -69,6 +75,18 @@ public class AccountController {
         throw new ResponseStatusException(HttpStatus.CONFLICT, "An account with that email already exists.");
     }
 
+    @GetMapping("/{userId}/survey/{surveyId}")
+    public ResponseEntity<Survey> getSurveyById(@PathVariable long surveyId, @PathVariable long userId) {
+        Optional<Survey> survey = surveyService.getSurveyById(surveyId);
+        if (survey.isPresent() && survey.get().getAccount().getId() == userId) {
+            return ResponseEntity.ok(survey.get());
+        } else {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+    }
+
     public record LoginRequest(String email, String password) {}
     public record RegisterRequest(String email, String password, String firstName, String lastName) {}
 }
+
+

--- a/backend/src/main/java/sysc4806group25/monkeypoll/controller/AccountController.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/controller/AccountController.java
@@ -14,15 +14,12 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.context.SecurityContextHolderStrategy;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
 import org.springframework.security.web.context.SecurityContextRepository;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 import sysc4806group25.monkeypoll.model.Account;
-import sysc4806group25.monkeypoll.model.Survey;
 import sysc4806group25.monkeypoll.service.AccountUserDetailsService;
-import sysc4806group25.monkeypoll.service.SurveyService;
-
-
-import java.util.Optional;
 
 @RestController
 public class AccountController {
@@ -32,9 +29,6 @@ public class AccountController {
 
     @Autowired
     AccountUserDetailsService accountUserDetailsService;
-
-    @Autowired
-    SurveyService surveyService;
 
     private SecurityContextRepository securityContextRepository =
             new HttpSessionSecurityContextRepository();
@@ -75,18 +69,6 @@ public class AccountController {
         throw new ResponseStatusException(HttpStatus.CONFLICT, "An account with that email already exists.");
     }
 
-    @GetMapping("/{userId}/survey/{surveyId}")
-    public ResponseEntity<Survey> getSurveyById(@PathVariable long surveyId, @PathVariable long userId) {
-        Optional<Survey> survey = surveyService.getSurveyById(surveyId);
-        if (survey.isPresent() && survey.get().getAccount().getId() == userId) {
-            return ResponseEntity.ok(survey.get());
-        } else {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
-        }
-    }
-
     public record LoginRequest(String email, String password) {}
     public record RegisterRequest(String email, String password, String firstName, String lastName) {}
 }
-
-

--- a/backend/src/main/java/sysc4806group25/monkeypoll/controller/SurveyController.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/controller/SurveyController.java
@@ -1,0 +1,58 @@
+package sysc4806group25.monkeypoll.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import sysc4806group25.monkeypoll.model.Question;
+import sysc4806group25.monkeypoll.model.Survey;
+import sysc4806group25.monkeypoll.service.SurveyService;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/surveys")
+public class SurveyController {
+
+    @Autowired
+    private SurveyService surveyService;
+
+    /**
+     * Retrieves a survey by its ID.
+     *
+     * @param surveyId the ID of the survey
+     * @return a ResponseEntity containing the survey if found, or a 404 status if not found
+     */
+    @GetMapping("/{surveyId}")
+    public ResponseEntity<Survey> getSurveyById(@PathVariable long surveyId) {
+        Optional<Survey> survey = surveyService.getSurveyById(surveyId);
+        System.out.println("surveys:" + surveyService.findAll());
+        return survey.map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
+    }
+
+    /**
+     * Retrieves the questions of a survey by its ID.
+     *
+     * @param surveyId the ID of the survey
+     * @return a ResponseEntity containing the list of questions in the survey
+     */
+    @GetMapping("/{surveyId}/questions")
+    public ResponseEntity<List<Question>> getSurveyQuestions(@PathVariable long surveyId) {
+        List<Question> questions = surveyService.getSurveyQuestions(surveyId);
+        return ResponseEntity.ok(questions);
+    }
+
+    /**
+     * Creates a new survey.
+     *
+     * @param survey the survey to be created
+     * @return a ResponseEntity containing the created survey with a 201 status
+     */
+    @PostMapping
+    public ResponseEntity<Survey> createSurvey(@RequestBody Survey survey) {
+        Survey createdSurvey = surveyService.createSurvey(survey.getDescription(), survey.getClosed());
+        return ResponseEntity.status(HttpStatus.CREATED).body(createdSurvey);
+    }
+}

--- a/backend/src/main/java/sysc4806group25/monkeypoll/controller/SurveyController.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/controller/SurveyController.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/surveys")
+@RequestMapping("/survey")
 public class SurveyController {
 
     @Autowired
@@ -27,7 +27,6 @@ public class SurveyController {
     @GetMapping("/{surveyId}")
     public ResponseEntity<Survey> getSurveyById(@PathVariable long surveyId) {
         Optional<Survey> survey = surveyService.getSurveyById(surveyId);
-        System.out.println("surveys:" + surveyService.findAll());
         return survey.map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
     }

--- a/backend/src/main/java/sysc4806group25/monkeypoll/model/ChoiceOption.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/model/ChoiceOption.java
@@ -1,5 +1,6 @@
 package sysc4806group25.monkeypoll.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 
 import java.util.ArrayList;
@@ -27,6 +28,7 @@ public class ChoiceOption {
     private ChoiceQuestion question;
 
     @OneToMany(mappedBy = "response", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
     private List<ChoiceResponse> responses = new ArrayList<>();
 
     /**

--- a/backend/src/main/java/sysc4806group25/monkeypoll/model/ChoiceQuestion.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/model/ChoiceQuestion.java
@@ -1,5 +1,6 @@
 package sysc4806group25.monkeypoll.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
@@ -23,6 +24,7 @@ public class ChoiceQuestion extends Question {
     private List<ChoiceOption> options = new ArrayList<>();
 
     @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
     private List<ChoiceResponse> responses = new ArrayList<>();
 
     /**

--- a/backend/src/main/java/sysc4806group25/monkeypoll/model/NumberQuestion.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/model/NumberQuestion.java
@@ -1,5 +1,6 @@
 package sysc4806group25.monkeypoll.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
@@ -37,6 +38,7 @@ public class NumberQuestion extends Question {
     private int maxValue;
 
     @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
     private List<NumberResponse> responses = new ArrayList<>();
 
     // GETTERS

--- a/backend/src/main/java/sysc4806group25/monkeypoll/model/Question.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/model/Question.java
@@ -1,5 +1,6 @@
 package sysc4806group25.monkeypoll.model;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 
 /**
@@ -23,6 +24,7 @@ public class Question {
 
     @ManyToOne
     @JoinColumn(name = "surveyId", nullable = false)
+    @JsonBackReference
     private Survey survey;
 
     /**

--- a/backend/src/main/java/sysc4806group25/monkeypoll/model/Survey.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/model/Survey.java
@@ -1,5 +1,7 @@
 package sysc4806group25.monkeypoll.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 
 import java.util.ArrayList;
@@ -23,14 +25,18 @@ public class Survey {
     private String description;
     private Boolean closed = false;
 
+    // Do not print account info with each survey
     @ManyToOne
     @JoinColumn(name = "accountId", nullable = false)
+    @JsonIgnore
     private Account account;
 
     @OneToMany(mappedBy = "survey", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SurveyCompletion> completions = new ArrayList<>();
 
+    // managed reference prevents Json from being printed recursively (bidirectional)
     @OneToMany(mappedBy = "survey", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
     private List<Question> questions;
 
     /**
@@ -47,6 +53,7 @@ public class Survey {
         this.description = description;
         this.closed = closed;
         this.account = account;
+        this.questions = new ArrayList<>();
     }
 
     /**

--- a/backend/src/main/java/sysc4806group25/monkeypoll/model/Survey.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/model/Survey.java
@@ -2,10 +2,12 @@ package sysc4806group25.monkeypoll.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.persistence.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * The Survey class models the survey entity for the MonkeyPoll application.
@@ -84,6 +86,16 @@ public class Survey {
      */
     public String getDescription() {
         return this.description;
+    }
+
+    /**
+     * @return list of question types in the survey
+     */
+    @JsonProperty("questionTypes")
+    public List<String> getQuestionTypes() {
+        return questions.stream()
+                .map(question -> question.getClass().getSimpleName())
+                .collect(Collectors.toList());
     }
 
     /**
@@ -182,4 +194,5 @@ public class Survey {
         this.completions.remove(completion);
         completion.setSurvey(null);
     }
+
 }

--- a/backend/src/main/java/sysc4806group25/monkeypoll/model/TextQuestion.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/model/TextQuestion.java
@@ -1,5 +1,6 @@
 package sysc4806group25.monkeypoll.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.OneToMany;
@@ -33,6 +34,7 @@ public class TextQuestion extends Question {
 
     // Fields
     @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonIgnore
     private List<TextResponse> responses = new ArrayList<>();
 
     // GETTERS

--- a/backend/src/main/java/sysc4806group25/monkeypoll/service/SurveyService.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/service/SurveyService.java
@@ -1,0 +1,61 @@
+package sysc4806group25.monkeypoll.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import sysc4806group25.monkeypoll.model.Question;
+import sysc4806group25.monkeypoll.model.Survey;
+import sysc4806group25.monkeypoll.repo.SurveyRepository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class SurveyService {
+
+    @Autowired
+    private SurveyRepository surveyRepository;
+
+    /**
+     * Creates a new survey with the given description and closed status.
+     *
+     * @param description the description of the survey
+     * @param closed whether the survey is closed
+     * @return the created survey
+     */
+    public Survey createSurvey(String description, boolean closed) {
+        Survey survey = new Survey(description, closed, null);
+        return surveyRepository.save(survey);
+    }
+
+    /**
+     * Retrieves a survey by its ID.
+     *
+     * @param surveyId the ID of the survey
+     * @return an Optional containing the survey if found, or empty if not found
+     */
+    public Optional<Survey> getSurveyById(long surveyId) {
+        return surveyRepository.findById(surveyId);
+    }
+
+    /**
+     * Retrieves the questions of a survey by its ID.
+     *
+     * @param surveyId the ID of the survey
+     * @return a list of questions in the survey, or an empty list if the survey is not found
+     */
+    public List<Question> getSurveyQuestions(long surveyId) {
+        return surveyRepository.findById(surveyId)
+                .map(Survey::getQuestions)
+                .orElse(Collections.emptyList());
+    }
+
+    /**
+     * Retrieves all surveys.
+     *
+     * @return a list of all surveys
+     */
+    public List<Survey> findAll() {
+        return (List<Survey>) surveyRepository.findAll();
+    }
+}

--- a/backend/src/test/java/sysc4806group25/monkeypoll/SurveyControllerTest.java
+++ b/backend/src/test/java/sysc4806group25/monkeypoll/SurveyControllerTest.java
@@ -65,7 +65,7 @@ public class SurveyControllerTest {
     @WithMockUser
     public void testGetSurveyById() throws Exception {
         // Perform a GET request to retrieve the survey by ID and verify the response
-        mockMvc.perform(get("/surveys/" + survey.getSurveyId())
+        mockMvc.perform(get("/survey/" + survey.getSurveyId())
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().json("{\"surveyId\":1,\"description\":\"Test Survey\",\"closed\":false,\"completions\":[],\"questions\":[{\"questionId\":0,\"question\":\"Question 1\"},{\"questionId\":0,\"question\":\"Question 2\"}]}"));

--- a/backend/src/test/java/sysc4806group25/monkeypoll/SurveyControllerTest.java
+++ b/backend/src/test/java/sysc4806group25/monkeypoll/SurveyControllerTest.java
@@ -1,0 +1,74 @@
+package sysc4806group25.monkeypoll;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import sysc4806group25.monkeypoll.model.*;
+import sysc4806group25.monkeypoll.repo.AccountRepository;
+import sysc4806group25.monkeypoll.repo.SurveyRepository;
+import sysc4806group25.monkeypoll.service.SurveyService;
+
+import java.util.Optional;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class SurveyControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private SurveyService surveyService;
+
+    @Autowired
+    private SurveyRepository surveyRepository;
+
+    @Autowired
+    private AccountRepository accountRepository;
+
+    private Survey survey;
+
+    @BeforeEach
+    public void setUp() {
+        // Create and save an account
+        Account account = new Account();
+        accountRepository.save(account);
+
+        // Create and save a survey associated with the account
+        survey = new Survey("Test Survey", false, account);
+        account.addSurvey(survey);
+        surveyRepository.save(survey);
+
+        // Create and add questions to the survey
+        TextQuestion question1 = new TextQuestion("Question 1", survey);
+        TextQuestion question2 = new TextQuestion("Question 2", survey);
+        survey.addQuestion(question1);
+        survey.addQuestion(question2);
+        surveyRepository.save(survey);
+
+        // Mock the surveyService to return the created survey when queried by ID
+        when(surveyService.getSurveyById(survey.getSurveyId())).thenReturn(Optional.of(survey));
+    }
+
+    @Test
+    @WithMockUser
+    public void testGetSurveyById() throws Exception {
+        // Perform a GET request to retrieve the survey by ID and verify the response
+        mockMvc.perform(get("/surveys/" + survey.getSurveyId())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().json("{\"surveyId\":1,\"description\":\"Test Survey\",\"closed\":false,\"completions\":[],\"questions\":[{\"questionId\":0,\"question\":\"Question 1\",\"responses\":[]},{\"questionId\":0,\"question\":\"Question 2\",\"responses\":[]}]}"));
+    }
+
+}

--- a/backend/src/test/java/sysc4806group25/monkeypoll/SurveyControllerTest.java
+++ b/backend/src/test/java/sysc4806group25/monkeypoll/SurveyControllerTest.java
@@ -68,7 +68,7 @@ public class SurveyControllerTest {
         mockMvc.perform(get("/survey/" + survey.getSurveyId())
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(content().json("{\"surveyId\":1,\"description\":\"Test Survey\",\"closed\":false,\"completions\":[],\"questions\":[{\"questionId\":0,\"question\":\"Question 1\"},{\"questionId\":0,\"question\":\"Question 2\"}]}"));
+                .andExpect(content().json("{\"surveyId\":1,\"description\":\"Test Survey\",\"closed\":false,\"completions\":[],\"questions\":[{\"questionId\":0,\"question\":\"Question 1\"},{\"questionId\":0,\"question\":\"Question 2\"}],\"questionTypes\":[\"TextQuestion\",\"TextQuestion\"]}"));
     }
 
 }

--- a/backend/src/test/java/sysc4806group25/monkeypoll/SurveyControllerTest.java
+++ b/backend/src/test/java/sysc4806group25/monkeypoll/SurveyControllerTest.java
@@ -68,7 +68,7 @@ public class SurveyControllerTest {
         mockMvc.perform(get("/surveys/" + survey.getSurveyId())
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(content().json("{\"surveyId\":1,\"description\":\"Test Survey\",\"closed\":false,\"completions\":[],\"questions\":[{\"questionId\":0,\"question\":\"Question 1\",\"responses\":[]},{\"questionId\":0,\"question\":\"Question 2\",\"responses\":[]}]}"));
+                .andExpect(content().json("{\"surveyId\":1,\"description\":\"Test Survey\",\"closed\":false,\"completions\":[],\"questions\":[{\"questionId\":0,\"question\":\"Question 1\"},{\"questionId\":0,\"question\":\"Question 2\"}]}"));
     }
 
 }


### PR DESCRIPTION
### Description

**Implemented Features:**
- Developed the initial `GET /survey` controller.
- Added survey details in the response, including:
  - `surveyId`
  - `description`
  - `status` (`closed`)
  - `completions` (list of completed responses)
  - `questions` (with associated details).

**Sample Response Body:**
```json
{
    "surveyId": 1,
    "description": "Test Survey",
    "closed": false,
    "completions": [],
    "questions": [
        {
            "questionId": 2,
            "question": "Test Question",
            "minValue": 0,
            "maxValue": 0
        },
        {
            "questionId": 1,
            "question": "Test Question"
        }
    ]
}
```

**Notes:**
- JSON annotations (`@JsonIgnore`) have been applied. Please review these carefully to ensure they align with our intended functionality.
- For now, the controller is unauthenticated due to incomplete functionality in `SecurityConfig`. This should be addressed once the controller is finalized.
- Included a screenshot showing the controller working in a simulated environment using Postman.  
![image](https://github.com/user-attachments/assets/9fb79b22-6d41-4add-9b1b-8d122a20a2a1)


---

### Additional Context
- Further work is required to implement the POST functionality for surveys, which is pending the completion of #54.
- @AminZeina, could you confirm possibly how we will do the Security Config for this endpoint
---

**Closes:** #56 