### PR TITLE
Feature #70: Close surveys endpoint

### DIFF
--- a/backend/src/main/java/sysc4806group25/monkeypoll/controller/AccountController.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/controller/AccountController.java
@@ -67,7 +67,6 @@ public class AccountController {
 
     @PostMapping("/register")
     public ResponseEntity<String> registerAccount(@RequestBody RegisterRequest registerRequest) {
-        //TODO: Validate inputs of RegisterRequest, which should be done in the record or a DTO
 
         if (accountUserDetailsService.isEmailUnique(registerRequest.email())) {
             Account newAccount = accountUserDetailsService.registerNewAccount(registerRequest);

--- a/backend/src/main/java/sysc4806group25/monkeypoll/controller/SurveyController.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/controller/SurveyController.java
@@ -330,4 +330,33 @@ public class SurveyController {
         return ResponseEntity.status(HttpStatus.CREATED).body("{\"message\":\"Survey response successfully submitted!\"}");
     }
 
+    /**
+     * This endpoint is responsible for closing the specified survey
+     *
+     * @param surveyId - the survey ID to close
+     * @return a ResponseEntity with a 204 status (success - No Content), a 409 status (error - conflict), or a
+     *         404 status if the survey is not found
+     */
+    @PostMapping("/user/survey/{surveyId}/close")
+    public ResponseEntity<?> closeSurvey(@PathVariable long surveyId) {
+        // Retrieve the survey by its ID
+        Optional<Survey> surveyOpt = surveyService.getSurveyById(surveyId);
+        if (surveyOpt.isEmpty()) {
+            // Return a 404 status if the survey is not found
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("{\"message\":\"Survey not found!\"}");
+        }
+        Survey survey = surveyOpt.get();
+
+        // Check if the survey is already closed
+        if (survey.getClosed()) {
+            // Return a 409 status if the survey is already closed
+            return ResponseEntity.status(HttpStatus.CONFLICT).body("{\"message\":\"Survey is already closed!\"}");
+        }
+
+        surveyService.closeSurvey(survey);
+
+        // Return the survey description, and the list of responses as the entire JSON response
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
 }

--- a/backend/src/main/java/sysc4806group25/monkeypoll/controller/SurveyController.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/controller/SurveyController.java
@@ -39,13 +39,26 @@ public class SurveyController {
      * Retrieves a survey by its ID.
      *
      * @param surveyId the ID of the survey
-     * @return a ResponseEntity containing the survey if found, or a 404 status if not found
+     * @return a ResponseEntity containing the survey if found, or a 403 status if closed, or a 404 status if not found
      */
     @GetMapping("/survey/{surveyId}")
     public ResponseEntity<?> getSurveyById(@PathVariable long surveyId) {
-        Optional<Survey> survey = surveyService.getSurveyById(surveyId);
-        return survey.map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.status(HttpStatus.NOT_FOUND).build());
+        Optional<Survey> surveyOpt = surveyService.getSurveyById(surveyId);
+        if (surveyOpt.isEmpty()) {
+            // Return a 404 status if the survey is not found
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("{\"message\":\"Survey not found!\"}");
+        }
+
+        Survey survey = surveyOpt.get();
+
+        // Check if the survey is closed
+        if (survey.getClosed()) {
+            // Return a 403 status if the survey is closed
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("{\"message\":\"Survey is closed!\"}");
+        }
+
+
+        return ResponseEntity.ok(survey);
     }
 
     /**

--- a/backend/src/main/java/sysc4806group25/monkeypoll/service/AccountUserDetailsService.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/service/AccountUserDetailsService.java
@@ -16,7 +16,6 @@ import java.util.Optional;
 @Service
 public class AccountUserDetailsService implements UserDetailsService {
 
-    //TODO: Need to merge Account Entity code to for this to work; Account entity must implement UserDetails
     @Autowired
     private AccountRepository accountRepository;
 

--- a/backend/src/main/java/sysc4806group25/monkeypoll/service/SurveyService.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/service/SurveyService.java
@@ -48,6 +48,20 @@ public class SurveyService {
     }
 
     /**
+     * Closes a survey
+     *
+     * @param survey the survey to be closed
+     * @return the closed survey
+     */
+    public Survey closeSurvey(Survey survey) {
+
+        // Close and save the survey
+        survey.setClosed(true);
+
+        return surveyRepository.save(survey);
+    }
+
+    /**
      * Retrieves a survey by its ID.
      *
      * @param surveyId the ID of the survey

--- a/backend/src/test/java/sysc4806group25/monkeypoll/SurveyControllerTest.java
+++ b/backend/src/test/java/sysc4806group25/monkeypoll/SurveyControllerTest.java
@@ -347,10 +347,7 @@ public class SurveyControllerTest {
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isNoContent());
 
-        this.mockMvc.perform(get("/survey/" + mockSurvey.getSurveyId())
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk())
-                .andExpect(content().json("{\"closed\": true}"));
+        assert surveyService.getSurveyById(mockSurvey.getSurveyId()).get().getClosed(); // ensure survey is closed
     }
 
     /**

--- a/frontend/src/api/surveyApi.js
+++ b/frontend/src/api/surveyApi.js
@@ -21,6 +21,10 @@ export const getSurvey = async (id) => {
     if (response.ok) {
         status.success = true;
         status.body = await response.json();
+    } else if (response.status === 403) {
+        status.body = await response.json();
+    } else if (response.status === 404) {
+        status.body = await response.json();
     }
 
     return status;

--- a/frontend/src/api/surveyApi.js
+++ b/frontend/src/api/surveyApi.js
@@ -174,6 +174,32 @@ export const getSurveyResults = async (surveyId) => {
     return status;
 }
 
+// Close a survey
+// Return:
+// - Success: True if survey has been closed
+// - Body - No content (204) on success or message describing the error
+export const postCloseSurvey = async (surveyId) => {
+
+    const requestOptions = {
+        method: 'POST',
+    };
+
+    const response = await fetch(`/user/survey/${surveyId}/close`, requestOptions);
+
+    const status = {
+        success: false,
+        body: {
+            message: "Failed to close survey"
+        }
+    }
+
+    if (response.ok) {
+        status.success = true;
+    }
+
+    return status;
+}
+
 // Get AI generated prompts for survey questions
 // Return:
 // - Success: True if prompts are generated

--- a/frontend/src/survey/CreateSurvey.jsx
+++ b/frontend/src/survey/CreateSurvey.jsx
@@ -27,7 +27,7 @@ const CreateSurvey = ({toast, setVisible}) => {
 
     const onSubmit = async () => {
         // Validate the form input before doing anything else, storing all error messages in a list
-        // TODO: currently only the first error is display, but storing all errors anyways in case we need them in the future
+        // currently only the first error is display, but storing all errors anyways in case we need them in the future
         let validation_errors = [];
 
         // Ensure that the survey has a name

--- a/frontend/src/survey/Surveys.jsx
+++ b/frontend/src/survey/Surveys.jsx
@@ -29,8 +29,8 @@ const Surveys = ({toast, setVisible}) => {
         }
     }
 
-    const closeSurvey = async (survey) => {
-        const status = await postCloseSurvey(survey.surveyId);
+    const closeSurvey = async (surveyId) => {
+        const status = await postCloseSurvey(surveyId);
         if (status.success) {
             await refreshSurveys();
         } else {
@@ -75,12 +75,11 @@ const Surveys = ({toast, setVisible}) => {
                     (rowData.closed) ?
                         <Button icon="pi pi-lock" className='p-button-text p-button-danger p-button-rounded'
                                 style={{boxShadow: "none"}}
-                                onClick={() => navigator.clipboard.writeText(rowData.surveyId)}
-                                tooltip="Click to open survey"/>
+                                tooltip="This survey is closed"/>
                         :
                         <Button icon="pi pi-lock-open" className='p-button-text p-button-rounded'
                                 style={{boxShadow: "none"}}
-                                onClick={() => navigator.clipboard.writeText(rowData.surveyId)}
+                                onClick={() => closeSurvey(rowData.surveyId)}
                                 tooltip="Click to close survey"/>
                 }
             </>

--- a/frontend/src/survey/Surveys.jsx
+++ b/frontend/src/survey/Surveys.jsx
@@ -4,7 +4,7 @@ import {UserContext} from "../context/UserContext.jsx";
 import {DataTable} from "primereact/datatable";
 import {Column} from "primereact/column";
 import {getUser} from "../api/userApi.js";
-import {getSurveyResults} from "../api/surveyApi.js";
+import {postCloseSurvey, getSurveyResults} from "../api/surveyApi.js";
 import SurveyResult from "./SurveyResult.jsx";
 
 const Surveys = ({toast, setVisible}) => {
@@ -30,11 +30,16 @@ const Surveys = ({toast, setVisible}) => {
     }
 
     const closeSurvey = async (survey) => {
-        // TODO Function should inverse the closed state of survey
-
-        const _user = await getUser();
-        if (_user.success) {
-            setUser(_user.body);
+        const status = await postCloseSurvey(survey.surveyId);
+        if (status.success) {
+            await refreshSurveys();
+        } else {
+            toast.current.show({
+                severity: 'error',
+                life: 3000,
+                summary: 'Close Survey Error',
+                detail: status.body.message,
+            });
         }
     }
 


### PR DESCRIPTION
Closes #70  and completes the TODO functionality of #73 .

### Changes
- Created `/user/survey/{surveyId}/close` endpoint which closes a survey; this is an empty POST which returns 204 on success
- Modified frontend to make the lock icons in the user's survey table call the new endpoint
- Added tests cases for the new endpoint

I've made the assumption that once a user closes a survey, that survey cannot be re-opened; I made this choice because reading the project requirements, it sounds like surveys should only be closed once. However, if we want to allow the user to re-open surveys let me know and I can make the necessary changes!

Comparison of open vs closed survey:
![image](https://github.com/user-attachments/assets/c3be3b81-1efa-40f5-918a-d0c581ca20ad)
