### PR TITLE
Feature 75: Implement the Circuit Breaker Pattern with Hystrix

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -16,6 +16,8 @@
     <properties>
         <java.version>21</java.version>
         <spring-ai.version>1.0.0-M4</spring-ai.version>
+        <spring.cloud-version>2021.0.0</spring.cloud-version>
+        <spring-cloud-starter-netflix-hystrix.version>2.2.10.RELEASE</spring-cloud-starter-netflix-hystrix.version>
     </properties>
 
     <dependencies>
@@ -79,7 +81,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-hystrix</artifactId>
-            <version>2.2.10.RELEASE</version>
+            <version>${spring-cloud-starter-netflix-hystrix.version}</version>
         </dependency>
     </dependencies>
 
@@ -89,6 +91,13 @@
                 <groupId>org.springframework.ai</groupId>
                 <artifactId>spring-ai-bom</artifactId>
                 <version>${spring-ai.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring.cloud-version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -76,6 +76,11 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-netflix-hystrix</artifactId>
+            <version>2.2.10.RELEASE</version>
+        </dependency>
     </dependencies>
 
     <dependencyManagement>

--- a/backend/src/main/java/sysc4806group25/monkeypoll/MonkeyPollApplication.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/MonkeyPollApplication.java
@@ -4,6 +4,7 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.cloud.netflix.hystrix.EnableHystrix;
 import org.springframework.context.annotation.Bean;
 import sysc4806group25.monkeypoll.model.*;
 import sysc4806group25.monkeypoll.repo.AccountRepository;
@@ -11,6 +12,7 @@ import sysc4806group25.monkeypoll.repo.SurveyRepository;
 
 @SpringBootApplication
 @EntityScan(basePackages = "sysc4806group25.monkeypoll.model")
+@EnableHystrix
 public class MonkeyPollApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/sysc4806group25/monkeypoll/controller/ChatController.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/controller/ChatController.java
@@ -28,7 +28,7 @@ public class ChatController {
     }
 
     @PostMapping("user/ai/generate")
-    @HystrixCommand(fallbackMethod = "handleAIProcessingError", commandProperties = {@HystrixProperty(name = "circuitBreaker.requestVolumeThreshold", value = "3"), @HystrixProperty(name = "circuitBreaker.sleepWindowInMilliseconds", value = "50000")})
+    @HystrixCommand(fallbackMethod = "handleAIProcessingError", commandProperties = {@HystrixProperty(name = "circuitBreaker.requestVolumeThreshold", value = "3"), @HystrixProperty(name = "circuitBreaker.sleepWindowInMilliseconds", value = "50000"), @HystrixProperty(name = "execution.isolation.thread.timeoutInMilliseconds", value = "10000")})
     public ResponseEntity<Map<String, ArrayList<String>>> generate(@RequestBody Map<String, String> request) {
         // Log when entering the endpoint
         logger.info("[/GENERATE ENDPOINT] Entered the endpoint to generate questions...");

--- a/backend/src/main/java/sysc4806group25/monkeypoll/controller/ChatController.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/controller/ChatController.java
@@ -26,10 +26,10 @@ public class ChatController {
     }
 
     @PostMapping("user/ai/generate")
-    @HystrixCommand(fallbackMethod = "handleAIProcessingError", commandProperties = {@HystrixProperty(name = "circuitBreaker.requestVolumeThreshold", value = "2"), @HystrixProperty(name = "circuitBreaker.sleepWindowInMilliseconds", value = "120000")})
+    @HystrixCommand(fallbackMethod = "handleAIProcessingError", commandProperties = {@HystrixProperty(name = "circuitBreaker.requestVolumeThreshold", value = "2"), @HystrixProperty(name = "circuitBreaker.sleepWindowInMilliseconds", value = "10000")})
     public ResponseEntity<Map<String, ArrayList<String>>> generate(@RequestBody Map<String, String> request) {
         // Log when entering the endpoint
-        logger.info("Entered usr/ai/generate endpoint to generate questions...");
+        logger.info("[/GENERATE ENDPOINT] Entered the endpoint to generate questions...");
 
         String message = request.getOrDefault("message", "").trim();
 
@@ -85,7 +85,7 @@ public class ChatController {
      * @return a SERVICE_UNAVAILABLE response
      */
     private ResponseEntity<Map<String, ArrayList<String>>> handleAIProcessingError(@RequestBody Map<String, String> request) {
-        logger.severe("[HYSTRIX] An exception was thrown while calling the AI model. Returning 503 response to frontend...");
+        logger.severe("[HYSTRIX FALLBACK METHOD] An exception was thrown while calling the AI model. Returning 503 response to frontend...");
         return new ResponseEntity<>(Map.of("questions", new ArrayList<>(Arrays.asList("(Hystrix) An exception occurred while generating the survey questions"))), HttpStatus.SERVICE_UNAVAILABLE);
     }
 }

--- a/backend/src/main/java/sysc4806group25/monkeypoll/controller/ChatController.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/controller/ChatController.java
@@ -1,5 +1,6 @@
 package sysc4806group25.monkeypoll.controller;
 
+import com.netflix.hystrix.contrib.javanica.annotation.HystrixCommand;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.vertexai.gemini.VertexAiGeminiChatModel;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +25,7 @@ public class ChatController {
     }
 
     @PostMapping("user/ai/generate")
+    @HystrixCommand(fallbackMethod = "handleAIGenerationError")
     public ResponseEntity<Map<String, ArrayList<String>>> generate(@RequestBody Map<String, String> request) {
         String message = request.getOrDefault("message", "").trim();
 
@@ -53,8 +55,8 @@ public class ChatController {
             return ResponseEntity.ok(Map.of("questions", questions));
 
         } catch (Exception e) {
-            logger.severe("Error calling the AI model: " + e.getMessage());
-            return new ResponseEntity<>(Map.of("questions", new ArrayList<>(Arrays.asList("An error occurred while generating the survey questions"))), HttpStatus.INTERNAL_SERVER_ERROR);
+            logger.severe("EXCEPTION THROWN DURING AI PROCESSING");
+            throw new RuntimeException();
         }
     }
 

--- a/backend/src/main/java/sysc4806group25/monkeypoll/controller/ChatController.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/controller/ChatController.java
@@ -26,7 +26,7 @@ public class ChatController {
     }
 
     @PostMapping("user/ai/generate")
-    @HystrixCommand(fallbackMethod = "handleAIProcessingError", commandProperties = {@HystrixProperty(name = "circuitBreaker.requestVolumeThreshold", value = "2"), @HystrixProperty(name = "circuitBreaker.sleepWindowInMilliseconds", value = "10000")})
+    @HystrixCommand(fallbackMethod = "handleAIProcessingError", commandProperties = {@HystrixProperty(name = "circuitBreaker.requestVolumeThreshold", value = "2"), @HystrixProperty(name = "circuitBreaker.sleepWindowInMilliseconds", value = "20000")})
     public ResponseEntity<Map<String, ArrayList<String>>> generate(@RequestBody Map<String, String> request) {
         // Log when entering the endpoint
         logger.info("[/GENERATE ENDPOINT] Entered the endpoint to generate questions...");

--- a/backend/src/main/java/sysc4806group25/monkeypoll/controller/ChatController.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/controller/ChatController.java
@@ -76,4 +76,18 @@ public class ChatController {
         // Convert the array into an ArrayList and return it
         return new ArrayList<>(Arrays.asList(questionsArray));
     }
+
+    /**
+     * The handleAIGenerationError method models the fallback method for the
+     * @HystrixCommand, which is the generate() endpoint method. When an exception
+     * is thrown in the endpoint method, it will use this method as its fallback to
+     * handle the exception. In this case, this method will handle th exception by
+     * returning a SERVICE_UNAVAILABLE response.
+     * @param request - the incoming request
+     * @return a SERVICE_UNAVAILABLE response
+     */
+    private ResponseEntity<Map<String, ArrayList<String>>> handleAIGenerationError(@RequestBody Map<String, String> request) {
+        logger.severe("[HYSTRIX] An exception was thrown while calling the AI model: ");
+        return new ResponseEntity<>(Map.of("questions", new ArrayList<>(Arrays.asList("(Hystrix) An exception occurred while generating the survey questions"))), HttpStatus.SERVICE_UNAVAILABLE);
+    }
 }

--- a/backend/src/main/java/sysc4806group25/monkeypoll/controller/ChatController.java
+++ b/backend/src/main/java/sysc4806group25/monkeypoll/controller/ChatController.java
@@ -25,7 +25,7 @@ public class ChatController {
     }
 
     @PostMapping("user/ai/generate")
-    @HystrixCommand(fallbackMethod = "handleAIGenerationError")
+    @HystrixCommand(fallbackMethod = "handleAIProcessingError")
     public ResponseEntity<Map<String, ArrayList<String>>> generate(@RequestBody Map<String, String> request) {
         String message = request.getOrDefault("message", "").trim();
 
@@ -86,7 +86,7 @@ public class ChatController {
      * @param request - the incoming request
      * @return a SERVICE_UNAVAILABLE response
      */
-    private ResponseEntity<Map<String, ArrayList<String>>> handleAIGenerationError(@RequestBody Map<String, String> request) {
+    private ResponseEntity<Map<String, ArrayList<String>>> handleAIProcessingError(@RequestBody Map<String, String> request) {
         logger.severe("[HYSTRIX] An exception was thrown while calling the AI model: ");
         return new ResponseEntity<>(Map.of("questions", new ArrayList<>(Arrays.asList("(Hystrix) An exception occurred while generating the survey questions"))), HttpStatus.SERVICE_UNAVAILABLE);
     }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,5 +1,4 @@
 spring.application.name=monkeyPoll
-logging.level.org.springframework.security=DEBUG
 server.error.include-message=always
 
 spring.ai.vertex.ai.gemini.project-id=monkeypoll

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 spring.application.name=monkeyPoll
+logging.level.org.springframework.security=DEBUG
 server.error.include-message=always
 
 spring.ai.vertex.ai.gemini.project-id=monkeypoll

--- a/frontend/src/api/surveyApi.js
+++ b/frontend/src/api/surveyApi.js
@@ -201,7 +201,9 @@ export const getAiQuestions = async (prompt) => {
     } else {
         // Check for 503 Service Unavailable response from backend (via Hystrix fallback method)
         if (response.status === 503) {
-            status.body.message = "Bob is unavailable at the moment. Please try again later";
+            status.body.message = "Uncle Bob is currently unavailable. Please try again later";
+        } else {
+            status.body.message = "Uncle Bob had some trouble generating questions for you. Can you try again?";
         }
     }
 

--- a/frontend/src/api/surveyApi.js
+++ b/frontend/src/api/surveyApi.js
@@ -198,6 +198,11 @@ export const getAiQuestions = async (prompt) => {
     if (response.ok) {
         status.success = true;
         status.body = await response.json();
+    } else {
+        // Check for 503 Service Unavailable response from backend (via Hystrix fallback method)
+        if (response.status === 503) {
+            status.body.message = "Bob is unavailable at the moment. Please try again later";
+        }
     }
 
     return status;

--- a/frontend/src/survey/CreateSurvey.jsx
+++ b/frontend/src/survey/CreateSurvey.jsx
@@ -161,6 +161,7 @@ const CreateSurvey = ({toast, setVisible}) => {
                _generatedQuestions.push(question);
             });
             setGeneratedQuestions(_generatedQuestions);
+            setGeneratedQuestionsVisible(true);
         } else {
             toast.current.show({
                 severity: 'error',
@@ -170,7 +171,6 @@ const CreateSurvey = ({toast, setVisible}) => {
             });
         }
         setLoading(false);
-        setGeneratedQuestionsVisible(true);
         if (!bobDialogVisible) return; setBobDialogVisible(false);
     }
 


### PR DESCRIPTION
### Summary of changes

- Implemented the Circuit Breaker Pattern with Hystrix, specifically for the /generate endpoint. 
- The command properties for the @HystrixCommand were set as follows: 
requestVolumeThreshold = 3 (i.e. After three requests have hit the endpoint, Hystrix will assess whether the circuit should be opened)
sleepWindowInMilliseconds = 50000 (i.e. how long the fallback method should be used before making the circuit transition into the half-open state, where Hystrix will use the next received request to determine whether the circuit should be closed (request is successful) or go back to being opened (request failed)

- When the circuit is opened, the fallback method will return a 503 response to the frontend. To display a different error message to the user, the frontend was changed to handle this response type.

(Note: For some reason, while the circuit is open, the circuit tends to prematurely move into the half-open state (meaning the endpoint can get called, but is in a 'test' phase. The next incoming request will be the deciding factor for whether the circuit should be closed or should go back to being open). To lessen the effects of this, I increased the sleepWindow from 20000 ms to 50000 ms (which definitely helped), but the circuit still goes into half-open state well before 50000 ms. I don't think this is too much of an issue, but I thought I would note it here)

